### PR TITLE
Simple changes for ILI_Ada_FontTest4

### DIFF
--- a/examples/ILI_Ada_FontTest4/ILI_Ada_FontTest4.ino
+++ b/examples/ILI_Ada_FontTest4/ILI_Ada_FontTest4.ino
@@ -38,7 +38,7 @@ const ili_fonts_test_t font_test_list[] = {
   {&Michroma_14, nullptr,  "Michroma_14", YELLOW, YELLOW},
   {&Crystal_24_Italic, nullptr,  "CRYSTAL_24", BLACK, YELLOW},
   {&Chancery_24_Italic, nullptr,  "Chancery_24_Italic", GREEN, GREEN},
-  {&OpenSans24, nullptr,  "OpenSans 18", RED, YELLOW},
+  {&OpenSans24, nullptr,  "OpenSans 24", RED, YELLOW},
   {nullptr, &FreeMonoBoldOblique12pt7b,  "GFX FreeMonoBoldOblique12pt7b", WHITE, WHITE},
   {nullptr, &FreeMonoBoldOblique12pt7b,  "GFX FreeMonoBoldOblique12pt7b", RED, YELLOW},
   {nullptr, &FreeSerif12pt7b,  "GFX FreeSerif12pt7b", WHITE, WHITE},
@@ -153,6 +153,7 @@ void loop()
     else if (font_test_list[font_index].gfx_font)  tft.setFont(font_test_list[font_index].gfx_font);
     else tft.setFontDef();
     tft.println(font_test_list[font_index].font_name);
+    Serial.printf("Showing font: %s\n", font_test_list[font_index].font_name);
     displayStuff1();
   }
   nextPage();

--- a/src/RA8876_Config_SPI.h
+++ b/src/RA8876_Config_SPI.h
@@ -11,7 +11,7 @@
 #define RA8876_CS 10
 #define RA8876_RESET 9
 //#define RA8876_CS 30
-//#define RA8876_RST 28
+//#define RA8876_RESET 28
 
 //Uncomment to to use 47MHz SPI clock. Default is 30MHz.
 #define USE_SPI_47000000


### PR DESCRIPTION
Opensans24 was showing as OpenSans 18

Added print of current font, name, which can help if there is an issue with the font being displayed.

In particular OpenSans24 is not properly outputting to the screen.

Also updated the config file as the settings I normally use had ..._RST but the sektchs are looking for _RESET